### PR TITLE
Fix serializer null check and add primitive serialization test

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -139,7 +139,7 @@ serializer.buildKey = function (hashKey, rangeKey, schema) {
 
 serializer.serializeItem = function (schema, item, options = {}) {
   var serialize = function (value, datatypes = {}) {
-    if(!value) {
+    if (value === undefined || value === null) {
       return null;
     }
 

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -244,6 +244,21 @@ describe('Serializer', function () {
       item.should.eql({age: 0});
     });
 
+    it('should serialize empty string attribute', function () {
+      var config = {
+        hashKey: 'name',
+        schema : {
+          name : Joi.string(),
+        }
+      };
+
+      var s = new Schema(config);
+
+      var item = serializer.serializeItem(s, {name: ''});
+
+      item.should.eql({name: ''});
+    });
+
 
     it('should serialize boolean attribute', function () {
       var config = {


### PR DESCRIPTION
## Summary
- ensure `serializer.serializeItem` doesn't treat falsey values as null
- add a test for serializing empty strings

## Testing
- `npm test` *(fails: Create Tables Integration Tests - should create table with hash key)*

------
https://chatgpt.com/codex/tasks/task_b_684909f7191883258567a02987caf5d6