### PR TITLE
Fix variable typo in batch and utils

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -59,7 +59,7 @@ internals.paginatedRequest = function (request, table, callback) {
     return request !== null && !_.isEmpty(request);
   };
 
-  var resulsFunc = function (err) {
+  var resultsFunc = function (err) {
     if(err) {
       return callback(err);
     }
@@ -67,7 +67,7 @@ internals.paginatedRequest = function (request, table, callback) {
     callback(null, internals.mergeResponses(table.tableName(), responses));
   };
 
-  async.doWhilst(doFunc, testFunc, resulsFunc);
+  async.doWhilst(doFunc, testFunc, resultsFunc);
 };
 
 internals.buckets = function (keys) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -99,7 +99,7 @@ utils.paginatedRequest = function (self, runRequestFunc, callback) {
     return (self.options.loadAll && lastEvaluatedKey) || retry;
   };
 
-  var resulsFunc = function (err) {
+  var resultsFunc = function (err) {
     if(err) {
       return callback(err);
     }
@@ -107,7 +107,7 @@ utils.paginatedRequest = function (self, runRequestFunc, callback) {
     return callback(null, utils.mergeResults(responses, self.table.tableName()));
   };
 
-  async.doWhilst(doFunc, testFunc, resulsFunc);
+  async.doWhilst(doFunc, testFunc, resultsFunc);
 };
 
 


### PR DESCRIPTION
## Summary
- rename `resulsFunc` to `resultsFunc` in batch.js
- rename `resulsFunc` to `resultsFunc` in utils.js

## Testing
- `npm test` *(fails: should create table with hash key)*

------
https://chatgpt.com/codex/tasks/task_b_68490a260b54832589ef3cc718bd3da7