### PR TITLE
Remove unused Query helper

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -249,14 +249,6 @@ Query.prototype.buildKey = function () {
   return expressions.buildFilterExpression(key, '=', existingValueKeys, this.hashKey);
 };
 
-internals.formatAttributeValue = function (val) {
-  if(_.isDate(val)) {
-    return val.toISOString();
-  }
-
-  return val;
-};
-
 Query.prototype.buildRequest = function () {
   return _.merge({}, this.request, {TableName: this.table.tableName()});
 };


### PR DESCRIPTION
## Summary
- delete unused `formatAttributeValue` helper from `lib/query.js`

## Testing
- `npm test` *(fails: Create Tables Integration Tests should create table with hash key)*

------
https://chatgpt.com/codex/tasks/task_b_68490ecf9dec83259d2f94537d089eb1