### PR TITLE
Update Node versions and Docker base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - 4
-  - 5
-  - 6
-  - 7
-  - 8
-  - 0.10
-  - 0.12
+  - 12
+  - 14
+  - 16
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM node:5-onbuild
+FROM node:14


### PR DESCRIPTION
## Summary
- test newer Node versions in CI
- use node:14 base image

## Testing
- `npm test` *(fails: missing DynamoDBLocal)*
- `npm run test-standalone` *(fails: 403 Forbidden when fetching DynamoDB local)*

------
https://chatgpt.com/codex/tasks/task_b_684911a3c8dc83259475975c9589126e