### PR TITLE
Fix AWS util initialization in helper

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,9 @@ var _        = require('lodash'),
     Readable = require('stream').Readable,
     streamToPromise = require('stream-to-promise'),
     async    = require('async'),
-    AWSUtil      = require('aws-sdk/lib/util');
+    AWS       = require('aws-sdk');
+
+var AWSUtil = AWS.util;
 
 var utils = module.exports;
 


### PR DESCRIPTION
## Summary
- fix binary string conversion utility by using initialized AWS util

## Testing
- `make lint`
- `node_modules/.bin/mocha test/*-test.js --reporter dot`
- `npm test` *(fails: Create Tables Integration Tests should create table with hash key)*

------
https://chatgpt.com/codex/tasks/task_b_68537b9cdfd48325a901b49e09a29b94