### PR TITLE
Fix local DynamoDB credentials in tests

### DIFF
--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -27,7 +27,13 @@ exports.mockDynamoDB = function () {
 };
 
 exports.realDynamoDB = function () {
-  var opts = { endpoint : 'http://localhost:8000', region: 'us-west-2', apiVersion: '2012-08-10' };
+  var opts = {
+    endpoint : 'http://localhost:8000',
+    region: 'us-west-2',
+    apiVersion: '2012-08-10',
+    accessKeyId: 'AKID',
+    secretAccessKey: 'SECRET'
+  };
   return new AWS.DynamoDB(opts);
 };
 


### PR DESCRIPTION
## Summary
- provide placeholder credentials for the DynamoDB client used in tests

## Testing
- `make test-unit`
- `npm test` *(fails: connection to DynamoDB Local refused)*

------
https://chatgpt.com/codex/tasks/task_b_68537b9cdfd48325a901b49e09a29b94