### PR TITLE
Skip integration tests when DynamoDB is not available

### DIFF
--- a/test/integration/create-table-test.js
+++ b/test/integration/create-table-test.js
@@ -13,8 +13,17 @@ chai.should();
 describe('Create Tables Integration Tests', function() {
   this.timeout(0);
 
-  before(function () {
-    dynamo.dynamoDriver(helper.realDynamoDB());
+  before(function (done) {
+    var self = this;
+    helper.isDynamoAvailable(function (available) {
+      if (!available) {
+        self.skip();
+        return done();
+      }
+
+      dynamo.dynamoDriver(helper.realDynamoDB());
+      done();
+    });
   });
 
   afterEach(function () {
@@ -367,9 +376,16 @@ describe('Update Tables Integration Tests', function() {
   now.description = 'Date.now()';
 
   before(function (done) {
-    dynamo.dynamoDriver(helper.realDynamoDB());
+    var self = this;
+    helper.isDynamoAvailable(function (available) {
+      if (!available) {
+        self.skip();
+        return done();
+      }
 
-    tableName = helper.randomName('dynamo-updateTable-Tweets');
+      dynamo.dynamoDriver(helper.realDynamoDB());
+
+      tableName = helper.randomName('dynamo-updateTable-Tweets');
 
     Tweet = dynamo.define('dynamo-update-table-test', {
       hashKey  : 'UserId',
@@ -379,11 +395,12 @@ describe('Update Tables Integration Tests', function() {
         UserId            : Joi.string(),
         TweetID           : dynamo.types.uuid(),
         content           : Joi.string(),
-        PublishedDateTime : Joi.date().default(now)
+      PublishedDateTime : Joi.date().default(now)
       }
     });
 
-    dynamo.createTables(done);
+      dynamo.createTables(done);
+    });
   });
 
   afterEach(function () {

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -74,14 +74,20 @@ describe('DynamoDB Integration Tests', function() {
   this.timeout(0);
 
   before(function (done) {
+    var self = this;
+    helper.isDynamoAvailable(function (available) {
+      if (!available) {
+        self.skip();
+        return done();
+      }
 
-    const generateId = () => uuidv4();
-    generateId.description = 'uuid.v4';
+      const generateId = () => uuidv4();
+      generateId.description = 'uuid.v4';
 
-    const now = () => Date.now();
-    now.description = 'Date.now()';
+      const now = () => Date.now();
+      now.description = 'Date.now()';
 
-    dynamo.dynamoDriver(helper.realDynamoDB());
+      dynamo.dynamoDriver(helper.realDynamoDB());
 
     User = dynamo.define('dynamo-int-test-user', {
       hashKey : 'id',
@@ -157,6 +163,7 @@ describe('DynamoDB Integration Tests', function() {
       },
       internals.loadSeedData
     ], done);
+  });
   });
 
   describe('#create', function () {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -100,3 +100,23 @@ exports.testLogger = function() {
     level : bunyan.FATAL
   });
 };
+
+const net = require('net');
+
+exports.isDynamoAvailable = function(callback) {
+  var socket = net.connect({host: 'localhost', port: 8000});
+  var called = false;
+
+  socket.on('connect', function() {
+    called = true;
+    socket.end();
+    callback(true);
+  });
+
+  socket.on('error', function() {
+    if (!called) {
+      called = true;
+      callback(false);
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- add helper check for DynamoDB connectivity
- skip integration test suites when DynamoDB local isn't running

## Testing
- `npx jshint test/**/*.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68537b9cdfd48325a901b49e09a29b94